### PR TITLE
Migrate suggest module and extension tests to OpenSearch 3.0 API

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     env:
-      PARENT_BRANCH: ${{ github.ref_name == 'master' && 'main' || github.ref_name }}
+      PARENT_BRANCH: main
 
     steps:
     - uses: actions/checkout@v4

--- a/src/main/java/org/codelibs/fess/suggest/Suggester.java
+++ b/src/main/java/org/codelibs/fess/suggest/Suggester.java
@@ -45,11 +45,11 @@ import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.opensearch.action.admin.indices.get.GetIndexResponse;
 import org.opensearch.action.admin.indices.refresh.RefreshResponse;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.cluster.metadata.AliasMetadata;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.transport.client.Client;
 
 /**
  * The Suggester class provides functionality for managing and querying suggestion indices.
@@ -337,7 +337,7 @@ public class Suggester {
     private long getNum(final QueryBuilder queryBuilder) {
         final SearchResponse searchResponse = client.prepareSearch().setIndices(getSearchAlias(index)).setSize(0).setQuery(queryBuilder)
                 .setTrackTotalHits(true).execute().actionGet(suggestSettings.getSearchTimeout());
-        return searchResponse.getHits().getTotalHits().value;
+        return searchResponse.getHits().getTotalHits().value();
     }
 
     private String getSearchAlias(final String index) {

--- a/src/main/java/org/codelibs/fess/suggest/SuggesterBuilder.java
+++ b/src/main/java/org/codelibs/fess/suggest/SuggesterBuilder.java
@@ -26,7 +26,7 @@ import org.codelibs.fess.suggest.normalizer.Normalizer;
 import org.codelibs.fess.suggest.settings.SuggestSettings;
 import org.codelibs.fess.suggest.settings.SuggestSettingsBuilder;
 import org.codelibs.fess.suggest.util.SuggestUtil;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * Builder class for creating instances of {@link Suggester}.

--- a/src/main/java/org/codelibs/fess/suggest/converter/AnalyzerConverter.java
+++ b/src/main/java/org/codelibs/fess/suggest/converter/AnalyzerConverter.java
@@ -23,8 +23,8 @@ import org.codelibs.fess.suggest.settings.AnalyzerSettings;
 import org.codelibs.fess.suggest.settings.SuggestSettings;
 import org.opensearch.action.admin.indices.analyze.AnalyzeAction;
 import org.opensearch.action.admin.indices.analyze.AnalyzeAction.AnalyzeToken;
-import org.opensearch.client.Client;
 import org.opensearch.core.common.Strings;
+import org.opensearch.transport.client.Client;
 
 import com.ibm.icu.text.Transliterator;
 

--- a/src/main/java/org/codelibs/fess/suggest/index/SuggestIndexer.java
+++ b/src/main/java/org/codelibs/fess/suggest/index/SuggestIndexer.java
@@ -29,7 +29,6 @@ import java.util.stream.Stream;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.core.lang.StringUtil;
-import org.codelibs.core.lang.ThreadUtil;
 import org.codelibs.fess.suggest.analysis.SuggestAnalyzer;
 import org.codelibs.fess.suggest.concurrent.Deferred;
 import org.codelibs.fess.suggest.constants.FieldNames;
@@ -50,11 +49,11 @@ import org.codelibs.fess.suggest.settings.SuggestSettings;
 import org.codelibs.fess.suggest.util.SuggestUtil;
 import org.opensearch.OpenSearchStatusException;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.index.query.Operator;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
+import org.opensearch.transport.client.Client;
 
 /**
  * The SuggestIndexer class is responsible for indexing and managing suggest items in an OpenSearch index.

--- a/src/main/java/org/codelibs/fess/suggest/index/contents/document/ESSourceReader.java
+++ b/src/main/java/org/codelibs/fess/suggest/index/contents/document/ESSourceReader.java
@@ -31,11 +31,11 @@ import org.codelibs.fess.suggest.settings.SuggestSettings;
 import org.codelibs.fess.suggest.util.SuggestUtil;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.sort.SortBuilder;
+import org.opensearch.transport.client.Client;
 
 /**
  * <p>
@@ -244,7 +244,7 @@ public class ESSourceReader implements DocumentReader {
     protected long getTotal() {
         final SearchResponse response = client.prepareSearch().setIndices(indexName).setQuery(queryBuilder).setSize(0)
                 .setTrackTotalHits(true).execute().actionGet(settings.getSearchTimeout());
-        return response.getHits().getTotalHits().value;
+        return response.getHits().getTotalHits().value();
     }
 
 }

--- a/src/main/java/org/codelibs/fess/suggest/index/writer/SuggestBulkFileWriter.java
+++ b/src/main/java/org/codelibs/fess/suggest/index/writer/SuggestBulkFileWriter.java
@@ -17,8 +17,8 @@ package org.codelibs.fess.suggest.index.writer;
 
 import org.codelibs.fess.suggest.entity.SuggestItem;
 import org.codelibs.fess.suggest.settings.SuggestSettings;
-import org.opensearch.client.Client;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.transport.client.Client;
 
 /**
  * SuggestBulkFileWriter is an implementation of the SuggestWriter interface.

--- a/src/main/java/org/codelibs/fess/suggest/index/writer/SuggestIndexWriter.java
+++ b/src/main/java/org/codelibs/fess/suggest/index/writer/SuggestIndexWriter.java
@@ -26,9 +26,9 @@ import org.opensearch.action.get.GetResponse;
 import org.opensearch.action.index.IndexAction;
 import org.opensearch.action.index.IndexRequest;
 import org.opensearch.action.index.IndexRequestBuilder;
-import org.opensearch.client.Client;
 import org.opensearch.common.unit.TimeValue;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.transport.client.Client;
 
 /**
  * SuggestIndexWriter is an implementation of the SuggestWriter interface that provides methods to write, delete,

--- a/src/main/java/org/codelibs/fess/suggest/index/writer/SuggestWriter.java
+++ b/src/main/java/org/codelibs/fess/suggest/index/writer/SuggestWriter.java
@@ -22,8 +22,8 @@ import java.util.Set;
 
 import org.codelibs.fess.suggest.entity.SuggestItem;
 import org.codelibs.fess.suggest.settings.SuggestSettings;
-import org.opensearch.client.Client;
 import org.opensearch.index.query.QueryBuilder;
+import org.opensearch.transport.client.Client;
 
 public interface SuggestWriter {
     /**

--- a/src/main/java/org/codelibs/fess/suggest/normalizer/AnalyzerNormalizer.java
+++ b/src/main/java/org/codelibs/fess/suggest/normalizer/AnalyzerNormalizer.java
@@ -21,7 +21,7 @@ import org.codelibs.fess.suggest.settings.AnalyzerSettings;
 import org.codelibs.fess.suggest.settings.SuggestSettings;
 import org.opensearch.action.admin.indices.analyze.AnalyzeAction;
 import org.opensearch.action.admin.indices.analyze.AnalyzeAction.AnalyzeToken;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * AnalyzerNormalizer is a class that implements the Normalizer interface.

--- a/src/main/java/org/codelibs/fess/suggest/request/Request.java
+++ b/src/main/java/org/codelibs/fess/suggest/request/Request.java
@@ -17,8 +17,8 @@ package org.codelibs.fess.suggest.request;
 
 import org.codelibs.fess.suggest.concurrent.Deferred;
 import org.codelibs.fess.suggest.exception.SuggesterException;
-import org.opensearch.client.Client;
 import org.opensearch.core.common.Strings;
+import org.opensearch.transport.client.Client;
 
 /**
  * Abstract class representing a request that can be executed to produce a response.

--- a/src/main/java/org/codelibs/fess/suggest/request/RequestBuilder.java
+++ b/src/main/java/org/codelibs/fess/suggest/request/RequestBuilder.java
@@ -16,7 +16,7 @@
 package org.codelibs.fess.suggest.request;
 
 import org.codelibs.fess.suggest.concurrent.Deferred;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * An abstract class that serves as a builder for creating and executing requests.

--- a/src/main/java/org/codelibs/fess/suggest/request/popularwords/PopularWordsRequest.java
+++ b/src/main/java/org/codelibs/fess/suggest/request/popularwords/PopularWordsRequest.java
@@ -27,7 +27,6 @@ import org.codelibs.fess.suggest.exception.SuggesterException;
 import org.codelibs.fess.suggest.request.Request;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.lucene.search.function.CombineFunction;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.index.query.BoolQueryBuilder;
@@ -37,6 +36,7 @@ import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.opensearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.rescore.QueryRescorerBuilder;
+import org.opensearch.transport.client.Client;
 
 public class PopularWordsRequest extends Request<PopularWordsResponse> {
     private String index = null;
@@ -190,7 +190,7 @@ public class PopularWordsRequest extends Request<PopularWordsResponse> {
             }
         }
 
-        return new PopularWordsResponse(index, searchResponse.getTook().getMillis(), words, searchResponse.getHits().getTotalHits().value,
+        return new PopularWordsResponse(index, searchResponse.getTook().getMillis(), words, searchResponse.getHits().getTotalHits().value(),
                 items);
     }
 }

--- a/src/main/java/org/codelibs/fess/suggest/request/popularwords/PopularWordsRequestBuilder.java
+++ b/src/main/java/org/codelibs/fess/suggest/request/popularwords/PopularWordsRequestBuilder.java
@@ -16,7 +16,7 @@
 package org.codelibs.fess.suggest.request.popularwords;
 
 import org.codelibs.fess.suggest.request.RequestBuilder;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * Builder for creating a {@link PopularWordsRequest} to fetch popular words.

--- a/src/main/java/org/codelibs/fess/suggest/request/suggest/SuggestRequest.java
+++ b/src/main/java/org/codelibs/fess/suggest/request/suggest/SuggestRequest.java
@@ -31,7 +31,6 @@ import org.codelibs.fess.suggest.normalizer.Normalizer;
 import org.codelibs.fess.suggest.request.Request;
 import org.opensearch.action.search.SearchRequestBuilder;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.lucene.search.function.CombineFunction;
 import org.opensearch.common.lucene.search.function.FieldValueFactorFunction;
 import org.opensearch.common.lucene.search.function.FunctionScoreQuery;
@@ -44,6 +43,7 @@ import org.opensearch.index.query.functionscore.FunctionScoreQueryBuilder;
 import org.opensearch.index.query.functionscore.ScoreFunctionBuilders;
 import org.opensearch.search.SearchHit;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.transport.client.Client;
 
 /**
  * SuggestRequest is a class that handles the request for suggestions.
@@ -373,7 +373,7 @@ public class SuggestRequest extends Request<SuggestResponse> {
         }
         firstWords.addAll(secondWords);
         firstItems.addAll(secondItems);
-        return new SuggestResponse(index, searchResponse.getTook().getMillis(), firstWords, searchResponse.getHits().getTotalHits().value,
+        return new SuggestResponse(index, searchResponse.getTook().getMillis(), firstWords, searchResponse.getHits().getTotalHits().value(),
                 firstItems);
     }
 

--- a/src/main/java/org/codelibs/fess/suggest/request/suggest/SuggestRequestBuilder.java
+++ b/src/main/java/org/codelibs/fess/suggest/request/suggest/SuggestRequestBuilder.java
@@ -18,7 +18,7 @@ package org.codelibs.fess.suggest.request.suggest;
 import org.codelibs.fess.suggest.converter.ReadingConverter;
 import org.codelibs.fess.suggest.normalizer.Normalizer;
 import org.codelibs.fess.suggest.request.RequestBuilder;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * Builder class for constructing {@link SuggestRequest} instances.

--- a/src/main/java/org/codelibs/fess/suggest/settings/AnalyzerSettings.java
+++ b/src/main/java/org/codelibs/fess/suggest/settings/AnalyzerSettings.java
@@ -39,11 +39,11 @@ import org.opensearch.action.admin.indices.analyze.AnalyzeAction.AnalyzeToken;
 import org.opensearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.opensearch.action.admin.indices.settings.get.GetSettingsResponse;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
+import org.opensearch.transport.client.Client;
 
 /**
  * The AnalyzerSettings class is responsible for managing and configuring analyzers for different fields and languages.

--- a/src/main/java/org/codelibs/fess/suggest/settings/ArraySettings.java
+++ b/src/main/java/org/codelibs/fess/suggest/settings/ArraySettings.java
@@ -36,7 +36,6 @@ import org.codelibs.fess.suggest.exception.SuggestSettingsException;
 import org.codelibs.fess.suggest.util.SuggestUtil;
 import org.opensearch.action.admin.indices.create.CreateIndexResponse;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.XContentFactory;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
@@ -44,6 +43,7 @@ import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
+import org.opensearch.transport.client.Client;
 
 /**
  * The ArraySettings class provides methods to manage settings stored in an array format within an OpenSearch index.
@@ -156,7 +156,7 @@ public class ArraySettings {
                     .actionGet(settings.getSearchTimeout());
             String scrollId = response.getScrollId();
 
-            final Map<String, Object>[] array = new Map[(int) response.getHits().getTotalHits().value];
+            final Map<String, Object>[] array = new Map[(int) response.getHits().getTotalHits().value()];
 
             int count = 0;
             try {

--- a/src/main/java/org/codelibs/fess/suggest/settings/BadWordSettings.java
+++ b/src/main/java/org/codelibs/fess/suggest/settings/BadWordSettings.java
@@ -23,8 +23,8 @@ import java.util.List;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.suggest.exception.SuggestSettingsException;
-import org.opensearch.client.Client;
 import org.opensearch.core.common.Strings;
+import org.opensearch.transport.client.Client;
 
 /**
  * The BadWordSettings class manages the settings related to bad words.

--- a/src/main/java/org/codelibs/fess/suggest/settings/ElevateWordSettings.java
+++ b/src/main/java/org/codelibs/fess/suggest/settings/ElevateWordSettings.java
@@ -25,7 +25,7 @@ import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.codelibs.fess.suggest.constants.FieldNames;
 import org.codelibs.fess.suggest.entity.ElevateWord;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * The ElevateWordSettings class manages the settings for elevate words in the suggestion system.

--- a/src/main/java/org/codelibs/fess/suggest/settings/SuggestSettings.java
+++ b/src/main/java/org/codelibs/fess/suggest/settings/SuggestSettings.java
@@ -31,12 +31,12 @@ import org.codelibs.core.lang.StringUtil;
 import org.codelibs.fess.suggest.exception.SuggestSettingsException;
 import org.codelibs.fess.suggest.exception.SuggesterException;
 import org.opensearch.action.get.GetResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.collect.Tuple;
 import org.opensearch.common.xcontent.XContentType;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.IndexNotFoundException;
+import org.opensearch.transport.client.Client;
 
 /**
  * The SuggestSettings class is responsible for managing the settings related to suggestions.

--- a/src/main/java/org/codelibs/fess/suggest/settings/SuggestSettingsBuilder.java
+++ b/src/main/java/org/codelibs/fess/suggest/settings/SuggestSettingsBuilder.java
@@ -20,7 +20,7 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.codelibs.fess.suggest.settings.SuggestSettings.TimeoutSettings;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 /**
  * Builder class for constructing SuggestSettings instances.

--- a/src/main/java/org/codelibs/fess/suggest/util/SuggestUtil.java
+++ b/src/main/java/org/codelibs/fess/suggest/util/SuggestUtil.java
@@ -49,12 +49,12 @@ import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.bulk.BulkResponse;
 import org.opensearch.action.delete.DeleteRequest;
 import org.opensearch.action.search.SearchResponse;
-import org.opensearch.client.Client;
 import org.opensearch.common.xcontent.json.JsonXContent;
 import org.opensearch.core.action.ActionListener;
 import org.opensearch.core.xcontent.XContentBuilder;
 import org.opensearch.index.query.QueryBuilder;
 import org.opensearch.search.SearchHit;
+import org.opensearch.transport.client.Client;
 
 public final class SuggestUtil {
     private static final int MAX_QUERY_TERM_NUM = 5;
@@ -143,7 +143,7 @@ public final class SuggestUtil {
             final List<BooleanClause> clauses = booleanQuery.clauses();
             final List<TermQuery> queryList = new ArrayList<>();
             for (final BooleanClause clause : clauses) {
-                final Query q = clause.getQuery();
+                final Query q = clause.query();
                 if (q instanceof BooleanQuery) {
                     queryList.addAll(getTermQueryList(q, fields));
                 } else if (q instanceof final TermQuery termQuery) {

--- a/src/test/java/org/codelibs/fess/suggest/SuggesterTest.java
+++ b/src/test/java/org/codelibs/fess/suggest/SuggesterTest.java
@@ -53,7 +53,7 @@ import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.index.IndexAction;
 import org.opensearch.action.index.IndexRequestBuilder;
 import org.opensearch.action.support.WriteRequest;
-import org.opensearch.client.Client;
+import org.opensearch.transport.client.Client;
 
 public class SuggesterTest {
     static Suggester suggester;

--- a/src/test/java/org/codelibs/fess/suggest/index/contents/document/ESSourceReaderTest.java
+++ b/src/test/java/org/codelibs/fess/suggest/index/contents/document/ESSourceReaderTest.java
@@ -37,10 +37,10 @@ import org.junit.Test;
 import org.opensearch.action.bulk.BulkRequestBuilder;
 import org.opensearch.action.index.IndexAction;
 import org.opensearch.action.index.IndexRequestBuilder;
-import org.opensearch.client.Client;
 import org.opensearch.index.IndexNotFoundException;
 import org.opensearch.search.sort.SortBuilders;
 import org.opensearch.search.sort.SortOrder;
+import org.opensearch.transport.client.Client;
 
 public class ESSourceReaderTest {
     static Suggester suggester;

--- a/src/test/java/org/codelibs/opensearch/extension/analysis/DisableGraphFilterFactory.java
+++ b/src/test/java/org/codelibs/opensearch/extension/analysis/DisableGraphFilterFactory.java
@@ -16,11 +16,11 @@
 package org.codelibs.opensearch.extension.analysis;
 
 import org.apache.lucene.analysis.TokenStream;
-import org.apache.lucene.analysis.miscellaneous.DisableGraphAttribute;
 import org.opensearch.common.settings.Settings;
 import org.opensearch.env.Environment;
 import org.opensearch.index.IndexSettings;
 import org.opensearch.index.analysis.AbstractTokenFilterFactory;
+import org.opensearch.lucene.analysis.miscellaneous.DisableGraphAttribute;
 
 public class DisableGraphFilterFactory extends AbstractTokenFilterFactory {
 

--- a/src/test/java/org/codelibs/opensearch/extension/analysis/NumberConcatenationFilterFactory.java
+++ b/src/test/java/org/codelibs/opensearch/extension/analysis/NumberConcatenationFilterFactory.java
@@ -42,7 +42,7 @@ public class NumberConcatenationFilterFactory extends AbstractTokenFilterFactory
         final String suffixWordsPath = settings.get("suffix_words_path");
 
         if (suffixWordsPath != null) {
-            final File suffixWordsFile = environment.configFile().resolve(suffixWordsPath).toFile();
+            final File suffixWordsFile = environment.configDir().resolve(suffixWordsPath).toFile();
             try (Reader reader = IOUtils.getDecodingReader(new FileInputStream(suffixWordsFile), StandardCharsets.UTF_8)) {
                 suffixWords = WordlistLoader.getWordSet(reader);
             } catch (final IOException e) {

--- a/src/test/java/org/codelibs/opensearch/extension/analysis/ReloadableKeywordMarkerFilterFactory.java
+++ b/src/test/java/org/codelibs/opensearch/extension/analysis/ReloadableKeywordMarkerFilterFactory.java
@@ -37,7 +37,7 @@ public class ReloadableKeywordMarkerFilterFactory extends AbstractTokenFilterFac
 
         final String path = settings.get("keywords_path");
         if (path != null) {
-            keywordPath = environment.configFile().resolve(path);
+            keywordPath = environment.configDir().resolve(path);
         } else {
             keywordPath = null;
         }

--- a/src/test/java/org/codelibs/opensearch/extension/analysis/ReloadableKuromojiTokenizerFactory.java
+++ b/src/test/java/org/codelibs/opensearch/extension/analysis/ReloadableKuromojiTokenizerFactory.java
@@ -103,7 +103,7 @@ public class ReloadableKuromojiTokenizerFactory extends AbstractTokenizerFactory
 
         final String monitoringFilePath = settings.get("user_dictionary");
         if (monitoringFilePath != null) {
-            final Path path = env.configFile().resolve(monitoringFilePath);
+            final Path path = env.configDir().resolve(monitoringFilePath);
 
             try {
                 final File file = path.toFile();

--- a/src/test/java/org/codelibs/opensearch/extension/analysis/ReloadableStopFilterFactory.java
+++ b/src/test/java/org/codelibs/opensearch/extension/analysis/ReloadableStopFilterFactory.java
@@ -39,7 +39,7 @@ public class ReloadableStopFilterFactory extends AbstractTokenFilterFactory {
 
         final String path = settings.get("stopwords_path");
         if (path != null) {
-            stopwordPath = environment.configFile().resolve(path);
+            stopwordPath = environment.configDir().resolve(path);
         } else {
             stopwordPath = null;
         }

--- a/src/test/java/org/codelibs/opensearch/extension/analysis/SynonymLoader.java
+++ b/src/test/java/org/codelibs/opensearch/extension/analysis/SynonymLoader.java
@@ -152,7 +152,7 @@ public class SynonymLoader {
                     throw new IllegalArgumentException("synonyms_path is not found.");
                 }
 
-                final Path path = env.configFile().resolve(filePath);
+                final Path path = env.configDir().resolve(filePath);
 
                 try {
                     final File file = path.toFile();


### PR DESCRIPTION
This pull request includes updates to the `Suggester` module and related components to improve compatibility with the `opensearch.transport.client.Client` library and modernize the codebase. Additionally, it fixes deprecated method usage for retrieving total hits in search responses.

### Library Updates:
* Replaced imports of `org.opensearch.client.Client` with `org.opensearch.transport.client.Client` across multiple files to align with updated library usage. [[1]](diffhunk://#diff-1c4697bcc5cee7d2512f42f25354f46b89c84f0ec0a926bf190592b15c782c35L48-R52) [[2]](diffhunk://#diff-912cfcb8bb8a8e139e73ad70000b7e5be300c124949d953679e49e1dd475f376L29-R29) [[3]](diffhunk://#diff-6b117b19cf9f83d3b2f5b8fd24714c6bac0fad57d3c4129b2c2bbf3ae734cee1L26-R27) [[4]](diffhunk://#diff-9a1799c66aad1b3e4c74fdc0bf4ab9315fc3aeb5f650f386159ab50490d1b87cL53-R56) [[5]](diffhunk://#diff-9abdfcbaa0d5f8e814678e373acfee64c364878916e7299870318a7fd5913272L34-R38) [[6]](diffhunk://#diff-7caa47b8ce213fafbbaa01dfe42743bdb4ea1931558c897fa335c4fe9708df4bL20-R21) [[7]](diffhunk://#diff-907df9ae3485cd5a7f9af10f76305c2ff35ee58fe173bc0ef9ed61464df59e8bL29-R31) [[8]](diffhunk://#diff-4141e12f684bf3cd091e1f3a67e67138bc52d440c85a5f098788f652fd8f1c8bL25-R26) [[9]](diffhunk://#diff-8fa24df7c52b642b78c70713a9069264f675866b2b8377a7ded7fe4a96babd96L24-R24) [[10]](diffhunk://#diff-91491a2e7010ebcfec1d3aac1f4228dd076689c8559d7d7ed69b17a3418f2271L20-R21) [[11]](diffhunk://#diff-4af257269acb715b0437589e79f89d780da340c1b21948bf9db14e48f3ec9289L19-R19) [[12]](diffhunk://#diff-7b2de9f3188f58b53cde1da515a8411c4c378e435c0f10c9396938e0833a21c9L30) [[13]](diffhunk://#diff-031fbca690d9782196fd904c0534f0ee4d1df722a1f58311e61165a3060ccf06R46) [[14]](diffhunk://#diff-ce02b5acc972520a9f14b4280ee7c8a2b11218570e466df7c742d1054d488d6fL21-R21) [[15]](diffhunk://#diff-b467ecf01259660ab714671ea2f87bb3e30b587fa9b5fbbaf0fb932fbe491f6fL42-R46) [[16]](diffhunk://#diff-5d426ffc1e263370f5fbc9f431bb4149dcbb7ed7d27e952e7d095d3f574a4ce4L39-R46) [[17]](diffhunk://#diff-a7dd4f3c0572b2ae99e5e540e0daff084d8f5a9420372f8fc663380ba4e42136L26-R27) [[18]](diffhunk://#diff-97ffac5a86d7b1fed7610cd8ed0c7536b690c4836ca235f738939b75d313e0bdL28-R28)

### Code Modernization:
* Updated deprecated method `getTotalHits().value` to `getTotalHits().value()` in several methods to ensure compatibility with newer versions of OpenSearch. [[1]](diffhunk://#diff-1c4697bcc5cee7d2512f42f25354f46b89c84f0ec0a926bf190592b15c782c35L340-R340) [[2]](diffhunk://#diff-9abdfcbaa0d5f8e814678e373acfee64c364878916e7299870318a7fd5913272L247-R247) [[3]](diffhunk://#diff-7b2de9f3188f58b53cde1da515a8411c4c378e435c0f10c9396938e0833a21c9L193-R193) [[4]](diffhunk://#diff-031fbca690d9782196fd904c0534f0ee4d1df722a1f58311e61165a3060ccf06L376-R376) [[5]](diffhunk://#diff-5d426ffc1e263370f5fbc9f431bb4149dcbb7ed7d27e952e7d095d3f574a4ce4L159-R159)

### Workflow Adjustment:
* Simplified the `PARENT_BRANCH` environment variable in `.github/workflows/maven.yml` to always use `main` instead of conditionally checking for `master`.