### PR TITLE
Remove unnecessary Javadoc link tags and fix formatting in analyzer and source reader classes

### DIFF
--- a/src/main/java/org/codelibs/fess/suggest/converter/AnalyzerConverter.java
+++ b/src/main/java/org/codelibs/fess/suggest/converter/AnalyzerConverter.java
@@ -46,11 +46,11 @@ import com.ibm.icu.text.Transliterator;
  *
  * <p>Inner Class:
  * <ul>
- *   <li>{@link LangAnayzerConverter}: A protected inner class that implements the ReadingConverter interface.
+ *   <li>LangAnayzerConverter: A protected inner class that implements the ReadingConverter interface.
  *       It is responsible for converting text using a specific language analyzer.
  *       <ul>
- *         <li>{@link LangAnayzerConverter#init()}: Initializes the converter. Currently does nothing.</li>
- *         <li>{@link LangAnayzerConverter#convert(String, String, String...)}: Converts the given text using the specified field and language.</li>
+ *         <li>LangAnayzerConverter#init(): Initializes the converter. Currently does nothing.</li>
+ *         <li>LangAnayzerConverter#convert(String, String, String...): Converts the given text using the specified field and language.</li>
  *       </ul>
  *   </li>
  * </ul>

--- a/src/main/java/org/codelibs/fess/suggest/index/contents/document/ESSourceReader.java
+++ b/src/main/java/org/codelibs/fess/suggest/index/contents/document/ESSourceReader.java
@@ -57,6 +57,7 @@ import org.opensearch.transport.client.Client;
  *
  * <p>
  * <b>Usage:</b>
+ * </p>
  * <pre>
  * {@code
  * Client client = // Obtain Elasticsearch client
@@ -77,7 +78,6 @@ import org.opensearch.transport.client.Client;
  * reader.close(); // Close the reader to release resources
  * }
  * </pre>
- * </p>
  */
 public class ESSourceReader implements DocumentReader {
     private static final Logger logger = LogManager.getLogger(ESSourceReader.class);


### PR DESCRIPTION
This pull request removes redundant @link tags from the Javadoc comments in AnalyzerConverter and corrects the misplaced paragraph tag in the usage section of ESSourceReader. These adjustments improve the readability and consistency of the documentation without altering any functional behavior.