### PR TITLE
Update parent POM version to 15.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.1.0-SNAPSHOT</version>
+		<version>15.1.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This pull request updates the parent POM version from 15.1.0-SNAPSHOT to 15.1.0 in the fess-suggest project’s pom.xml. This change aligns the project with the finalized version of fess-parent, indicating readiness for the official 15.1.0 release.
