### PR TITLE
Update parent POM version from snapshot to release 15.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.2.0-SNAPSHOT</version>
+		<version>15.2.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
This pull request updates the parent version in the `pom.xml` file from a snapshot version to a release version, reflecting a move to a stable release.

* Dependency version update:
  * Changed the parent `fess-parent` version from `15.2.0-SNAPSHOT` to `15.2.0` in `pom.xml`, indicating a transition to the official release.