### PR TITLE
chore(pom): update fess-parent version to 15.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.6.0-SNAPSHOT</version>
+		<version>15.6.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary
Update the fess-parent version from `15.6.0-SNAPSHOT` to `15.6.0` to align with the stable release.

## Changes Made
- Updated `pom.xml` parent version from `15.6.0-SNAPSHOT` to `15.6.0`

## Testing
- No functional changes; dependency version bump only

## Breaking Changes
- None

## Additional Notes
- This follows the previous version bump to 15.6.0-SNAPSHOT in commit 4625b2b