### PR TITLE
chore(pom): update fess-parent version to 15.7.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.7.0-SNAPSHOT</version>
+		<version>15.7.0</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

Update the `fess-parent` reference in `pom.xml` to the released `15.7.0` (was `15.7.0-SNAPSHOT`).

fess-parent 15.7.0 has been published to Maven Central, so the build now points at the released parent POM. The project version stays on `15.7.0-SNAPSHOT`.
