### PR TITLE
Update version to 15.8.0-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>fess-suggest</artifactId>
-	<version>15.7.1-SNAPSHOT</version>
+	<version>15.8.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 	<name>fess-suggest</name>
 	<url>https://fess.codelibs.org/</url>
@@ -36,7 +36,7 @@
 	<parent>
 		<groupId>org.codelibs.fess</groupId>
 		<artifactId>fess-parent</artifactId>
-		<version>15.7.0</version>
+		<version>15.8.0-SNAPSHOT</version>
 		<relativePath />
 	</parent>
 	<build>


### PR DESCRIPTION
## Summary

Bump version for the 15.8.0 development cycle.

Depends on upstream Fess artifacts (`fess-parent`, and where applicable `fess-suggest`, `fess-crawler`, `fess-crawler-playwright`, `fess`) at `15.8.0-SNAPSHOT`, which must already be deployed to the Maven snapshot repository before CI runs here.

## Test plan

- [ ] CI build passes against `15.8.0-SNAPSHOT` upstreams