### PR TITLE
build: deploy to maven.codelibs.org instead of Maven Central

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Java CI with Maven](https://github.com/codelibs/fess-suggest/actions/workflows/maven.yml/badge.svg)](https://github.com/codelibs/fess-suggest/actions/workflows/maven.yml)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.codelibs.fess/fess-suggest/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.codelibs.fess/fess-suggest)
+[![Maven Repository](https://img.shields.io/badge/Maven-maven.codelibs.org-blue)](https://maven.codelibs.org/release/org/codelibs/fess/fess-suggest/)
 
 A powerful Java library that provides intelligent search suggestion functionality built on top of OpenSearch/Elasticsearch. It offers auto-completion, query suggestions, and popular word analytics for search applications.
 
@@ -36,7 +36,20 @@ A powerful Java library that provides intelligent search suggestion functionalit
 
 ### Installation
 
-Add the dependency to your `pom.xml`:
+Releases are published to the CodeLibs Maven repository rather than Maven Central, so declare it
+in your `pom.xml` first:
+
+```xml
+<repositories>
+    <repository>
+        <id>codelibs.org</id>
+        <name>CodeLibs Repository</name>
+        <url>https://maven.codelibs.org/release/</url>
+    </repository>
+</repositories>
+```
+
+Then add the dependency:
 
 ```xml
 <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -41,14 +41,6 @@
 	</parent>
 	<build>
 		<plugins>
-			<!-- This project publishes to Maven Central. fess-parent only manages this
-			     plugin in pluginManagement, because the Fess plugins deploy to
-			     maven.codelibs.org instead. -->
-			<plugin>
-				<groupId>org.sonatype.central</groupId>
-				<artifactId>central-publishing-maven-plugin</artifactId>
-				<extensions>true</extensions>
-			</plugin>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
 			</plugin>
@@ -90,6 +82,25 @@
 			</plugin>
 		</plugins>
 	</build>
+	<!-- Distributed through maven.codelibs.org instead of Maven Central. This cannot be
+	     inherited from fess-parent: distributionManagement is inherited unconditionally
+	     and a POM cannot exempt itself from what it declares, so declaring it there
+	     would also redirect the deployments of fess-parent itself, which stays on Maven
+	     Central so that every project inheriting from it can resolve the parent POM
+	     without extra repository configuration. The scpexe transport comes from the
+	     wagon-ssh-external build extension inherited from fess-parent. -->
+	<distributionManagement>
+		<repository>
+			<id>codelibs-repo</id>
+			<name>CodeLibs Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/release</url>
+		</repository>
+		<snapshotRepository>
+			<id>codelibs-snapshots</id>
+			<name>CodeLibs Snapshot Repository</name>
+			<url>scpexe://maven.codelibs.org/var/www/maven/snapshot</url>
+		</snapshotRepository>
+	</distributionManagement>
 	<repositories>
 		<repository>
 			<id>snapshots.central.sonatype.com</id>


### PR DESCRIPTION
## Summary

Publish this project to `maven.codelibs.org` instead of Maven Central, matching the Fess plugins.

## Changes

- Remove the `central-publishing-maven-plugin` declaration from `build/plugins`
- Declare the CodeLibs release and snapshot repositories in `distributionManagement`
- `README.md`: replace the Maven Central badge and show consumers the repository they now have to declare

## Why it is done this way

Removing the plugin declaration is the part that actually switches the destination. `central-publishing-maven-plugin` registers a `DeployLifecycleParticipant` that clears `maven-deploy-plugin`'s executions whenever the plugin is present in `build/plugins`, so adding `distributionManagement` on its own would have had no effect at all.

`distributionManagement` cannot be inherited from `fess-parent`: it is inherited unconditionally and a POM cannot exempt itself from what it declares, so declaring it there would also redirect `fess-parent`'s own deployments. `fess-parent` has to stay on Maven Central, because a parent POM is only resolvable from repositories the consuming project already knows about — see codelibs/fess-parent#66.

The `scpexe` transport comes from the `wagon-ssh-external` build extension inherited from `fess-parent`.

## Verification

- `mvn -B validate` no longer reports `Installing Central Publishing features`, so the lifecycle participant is inactive
- The effective `distributionManagement` snapshot URL resolves to the CodeLibs snapshot repository
- `mvn deploy` to a local file repository writes the POM, jar, sources jar and metadata — the participant would have suppressed this had it still been active

## Note

The `javadoc.io` badge is served from Maven Central, so it will stop tracking new releases after this change. Left as-is for now.
